### PR TITLE
Trapping error for net-http2

### DIFF
--- a/lib/apnotic/connection.rb
+++ b/lib/apnotic/connection.rb
@@ -28,6 +28,7 @@ module Apnotic
       raise "Cert file not found: #{@cert_path}" unless @cert_path && (@cert_path.respond_to?(:read) || File.exist?(@cert_path))
 
       @client = NetHttp2::Client.new(@url, ssl_context: ssl_context, connect_timeout: @connect_timeout)
+      @client.on(:error) { |exception| puts "Exception has been raised in Apnotic: #{exception}" }
     end
 
     def push(notification, options={})

--- a/lib/apnotic/version.rb
+++ b/lib/apnotic/version.rb
@@ -1,3 +1,3 @@
 module Apnotic
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
https://varsity.atlassian.net/browse/INFR-665

According to the docs found here: https://github.com/ostinelli/net-http2 it is highly recommended to set the `:error` callback so any exceptions don't make their way back to the main application thread.